### PR TITLE
Fix ImportError for 'main' from 'evo_downloader.__main__'

### DIFF
--- a/evo_downloader/__main__.py
+++ b/evo_downloader/__main__.py
@@ -2,5 +2,8 @@
 
 from .cli import cli  # pragma: no cover
 
+def main():
+    cli()
+
 if __name__ == "__main__":  # pragma: no cover
-    cli()  # pragma: no cover
+    main()  # pragma: no cover


### PR DESCRIPTION
Define a `main` function in `evo_downloader/__main__.py` to fix ImportError.

* Define a `main` function that calls the `cli` function.
* Update the `if __name__ == "__main__"` block to call the `main` function instead of `cli`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/maycuatroi/evo_downloader?shareId=604aaf42-8916-4866-8412-bdb9450f2c5f).